### PR TITLE
Simplifying React Component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react", "es2015"]
+  "presets": ["react", "es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "homepage": "https://github.com/Ahrengot/react-svg-use#readme",
   "dependencies": {
-  	"react": ">=0.14.3"
+    "react": ">=0.14.3"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18"
   }

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
 [![npm version](https://badge.fury.io/js/react-svg-use.svg)](https://badge.fury.io/js/react-svg-use)
 
-# Enable SVG `<use />` in React.js
+# SVG `<Use />` React.js Component
 
-[SVG sprites are awesome](https://css-tricks.com/svg-sprites-use-better-icon-fonts/), but they don't work out of the box with React.js, because `xlink:href` is not a standardly-supported SVG attribute. This component works around that limitation.
+[SVG sprites are awesome](https://css-tricks.com/svg-sprites-use-better-icon-fonts/)! This component saves you the time building and maintaining your own `<Use />` react component within your React.js projects.
 
 ## Installation
 `npm i react-svg-use -S`
 
 ## How do I ... use it?
-First, set up your SVG sprite sheet so you have something simmilar to this:
+First, set up your SVG sprite sheet so you have something similar to this:
 
-```xml
+```html
 <svg xmlns="http://www.w3.org/2000/svg" style="display:none;">
   <symbol id="car">
     <path d="..."/>
@@ -26,13 +26,17 @@ First, set up your SVG sprite sheet so you have something simmilar to this:
 
 Then, simply import and use the icon where you need it
 
-```JavaScript
+```javaScript
 import Icon from 'react-svg-use'
 
 React.createClass({
   render() {
     return (
-      <Icon id='car' color='#D71421' />
+      <Icon
+        xlink='car'
+        fillColor='#D71421'
+        className='car-icon'
+      />
     )
   }
 })
@@ -41,7 +45,7 @@ React.createClass({
 The above snippet generates markup looking like this. Any additional `props` passed to the component will be added to the wrapping SVG element. For instance `className`, `id` etc.
 
 ```html
-<svg>
+<svg class="car-icon">
   <use xlink:href="#car" style="fill:#D71421;"></use>
 </svg>
 ```

--- a/src/react-svg-use.js
+++ b/src/react-svg-use.js
@@ -1,17 +1,8 @@
-import DOMProperty from 'react/lib/DOMProperty';
-
-// xlink:href is not a standardly-supported svg attribute, but you can tell
-// React that it is ok.
-DOMProperty.injection.injectDOMPropertyConfig({
-  isCustomAttribute: function (attributeName) {
-    return (attributeName === 'xlink:href');
-  }
-});
-
 export default props => {
+    const { xlink, fillColor, ...other } = props;
 	return (
-		<svg { ...props } >
-			{ React.createElement('use', { 'xlink:href': '#' + props.id, style: { fill: props.color } }) }
+		<svg { ...other }>
+            <use xlinkHref={ '#' + xlink } style={{ fill: fillColor }} />
 		</svg>
 	)
 }

--- a/src/react-svg-use.js
+++ b/src/react-svg-use.js
@@ -1,8 +1,10 @@
+import React from 'react';
+
 export default props => {
-    const { xlink, fillColor, ...other } = props;
-	return (
-		<svg { ...other }>
-            <use xlinkHref={ '#' + xlink } style={{ fill: fillColor }} />
-		</svg>
-	)
+    const {xlink, fillColor, ...other} = props;
+    return (
+        <svg {...other}>
+            <use xlinkHref={'#' + xlink} style={{fill: fillColor}} />
+        </svg>
+    )
 }


### PR DESCRIPTION
- simplifies `react-svg-use` component: [release notes](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#notable-enhancements) for `0.14`
- fixes build error: `ReferenceError: React is not defined`
- prevents forcing `id` attribute on `svg` tag
- more precise naming

Added `transform-object-rest-spread` as a `dev-dependency`.
